### PR TITLE
Fix for the sound cutting out on HomePod mini 26

### DIFF
--- a/application/squeezelite/output_raop.c
+++ b/application/squeezelite/output_raop.c
@@ -105,7 +105,7 @@ static void *output_raop_thread(struct thread_ctx_s *ctx) {
 		UNLOCK;
 
 		// nothing to do, sleep
-		if (!ran) usleep(10000);
+		if (!ran) usleep(2000);
 	}
 
 	return 0;


### PR DESCRIPTION
After upgrading HomePod mini OS to 26, the airplay sound cuts out frequently.
It is likely due to some change in HomePod OS, perhaps smaller latency or buffering.
Shorter sleep time (2ms) works fine.