### PR TITLE
Sync device time on remote streaming start

### DIFF
--- a/application/squeezelite/output.c
+++ b/application/squeezelite/output.c
@@ -210,6 +210,14 @@ frames_t _output_frames(frames_t avail, struct thread_ctx_s *ctx) {
 		}
 	}
 
+	if (!ctx->output.detect_end_time && !silence && ctx->output.state == OUTPUT_RUNNING && _buf_used(ctx->outputbuf) == 0) {
+		ctx->output.detect_end_time = true;
+		ctx->output.last_track_end_time = gettime_ms();
+		LOG_INFO("[%p]: track end detected at %u ms", ctx, ctx->output.last_track_end_time);
+	} else if (silence) {
+		ctx->output.detect_end_time = false;
+	}
+
 	LOG_SDEBUG("[%p]: wrote %u frames", ctx, frames);
 
 	return frames;
@@ -306,6 +314,7 @@ void output_init_common(void *device, unsigned outputbuf_size, u32_t sample_rate
 	ctx->output.device = device;
 	ctx->output.error_opening = false;
 	ctx->output.detect_start_time = false;
+	ctx->output.detect_end_time = false;
 
 	ctx->output.current_sample_rate = ctx->output.default_sample_rate = sample_rate;
 	ctx->output.supported_rates[0] = sample_rate;

--- a/application/squeezelite/output_raop.c
+++ b/application/squeezelite/output_raop.c
@@ -90,6 +90,8 @@ static void *output_raop_thread(struct thread_ctx_s *ctx) {
 					ctx->output.track_start_time = NTP2MS(playtime);
 					LOG_INFO("[%p]: track actual start time:%u (gap:%d)", ctx, ctx->output.track_start_time,
 										(s32_t) (ctx->output.track_start_time - ctx->output.start_at));
+					raopcl_flush(ctx->output.device);
+					raopcl_stop(ctx->output.device);
 				}
 
 				ctx->output.buf_frames = 0;

--- a/application/squeezelite/output_raop.c
+++ b/application/squeezelite/output_raop.c
@@ -66,6 +66,24 @@ void output_close(struct thread_ctx_s *ctx)
 	free(ctx->output.buf);
 }
 
+/*---------------------------------------------------------------------------*/
+static void _raop_flush_at_track_start(struct thread_ctx_s *ctx) {
+	u32_t gap;
+	u32_t safety_ms = 200;
+
+	if (!ctx->output.detect_end_time) {
+		return;
+	}
+	ctx->output.detect_end_time = false;
+	gap = gettime_ms() - ctx->output.last_track_end_time;
+	if (gap > safety_ms) {
+		LOG_INFO("[%p]: gap between last track end and current track start is large(%u ms > %u ms), sync device time",
+			ctx, gap, safety_ms);
+		// flush and stop to sync device time
+		raopcl_flush(ctx->output.device);
+		raopcl_stop(ctx->output.device);
+	}
+}
 
 /*---------------------------------------------------------------------------*/
 static void *output_raop_thread(struct thread_ctx_s *ctx) {
@@ -90,8 +108,7 @@ static void *output_raop_thread(struct thread_ctx_s *ctx) {
 					ctx->output.track_start_time = NTP2MS(playtime);
 					LOG_INFO("[%p]: track actual start time:%u (gap:%d)", ctx, ctx->output.track_start_time,
 										(s32_t) (ctx->output.track_start_time - ctx->output.start_at));
-					raopcl_flush(ctx->output.device);
-					raopcl_stop(ctx->output.device);
+					_raop_flush_at_track_start(ctx);
 				}
 
 				ctx->output.buf_frames = 0;

--- a/application/squeezelite/squeezelite.h
+++ b/application/squeezelite/squeezelite.h
@@ -437,6 +437,8 @@ struct outputstate {
 	};
 	u8_t  *track_start;        // set in decode thread
 	bool  detect_start_time;   // use in audio extractor
+	bool  detect_end_time;     // use in audio extractor
+	u32_t last_track_end_time;
 	u32_t gainL;               // set by slimproto
 	u32_t gainR;               // set by slimproto
 	u32_t next_replay_gain;    // set by slimproto


### PR DESCRIPTION
If the playlist has remote streaming tracks and getting the next streaming is delayed, the beginning of the next track is missing. We synchronize the device time by `raopcl_flush` and `raopcl_stop` since the time of the device is running while getting the next streaming url.
Sync would be executed in the next `raopcl_accept_frames`.